### PR TITLE
feat: redesign button components with fantasy theme

### DIFF
--- a/src/components/CharacterSheet/CharacterSheet.tsx
+++ b/src/components/CharacterSheet/CharacterSheet.tsx
@@ -74,7 +74,7 @@ export function CharacterSheet() {
             <>
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 onClick={undo}
                 disabled={!canUndo}
                 title="Undo (Ctrl+Z)"
@@ -84,7 +84,7 @@ export function CharacterSheet() {
               </Button>
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 onClick={redo}
                 disabled={!canRedo}
                 title="Redo (Ctrl+Y)"
@@ -94,8 +94,8 @@ export function CharacterSheet() {
               </Button>
               <div className="w-px h-6 bg-slate-300 dark:bg-slate-600 mx-1 hidden sm:block" />
               <Button
-                variant="default"
-                size="sm"
+                variant="primary"
+                size="small"
                 onClick={handleSave}
                 disabled={!canSave}
               >
@@ -104,7 +104,7 @@ export function CharacterSheet() {
               </Button>
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 onClick={cancelChanges}
               >
                 <X className="w-4 h-4 mr-2" />
@@ -113,8 +113,8 @@ export function CharacterSheet() {
             </>
           )}
           <Button
-            variant={isEditMode ? "ghost" : "default"}
-            size="sm"
+            variant={isEditMode ? "ghost" : "primary"}
+            size="small"
             onClick={handleEditToggle}
             className="touch-target"
           >

--- a/src/components/CharacterSheet/components/AbilityScoresWithDice.tsx
+++ b/src/components/CharacterSheet/components/AbilityScoresWithDice.tsx
@@ -73,7 +73,7 @@ export function AbilityScoresWithDice({ character, isEditMode = false }: Ability
             >
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 className={cn(
                   "absolute -top-2 -right-2 h-6 w-6 p-0",
                   "opacity-0 group-hover:opacity-100 transition-opacity",

--- a/src/components/CharacterSheet/components/DeathSavesWithDice.tsx
+++ b/src/components/CharacterSheet/components/DeathSavesWithDice.tsx
@@ -53,8 +53,8 @@ export function DeathSavesWithDice({ character }: DeathSavesWithDiceProps) {
       </h3>
       
       <Button
-        variant="outline"
-        size="sm"
+        variant="ghost"
+        size="small"
         className={cn(
           "absolute top-4 right-4",
           "print:hidden"

--- a/src/components/CharacterSheet/components/QuickStats.tsx
+++ b/src/components/CharacterSheet/components/QuickStats.tsx
@@ -43,7 +43,7 @@ export function QuickStats({ character }: QuickStatsProps) {
         </div>
         <Button
           variant="ghost"
-          size="sm"
+          size="small"
           className={cn(
             "absolute -top-2 -right-2 h-6 w-6 p-0",
             "opacity-0 group-hover:opacity-100 transition-opacity",

--- a/src/components/CharacterSheet/components/SavingThrowsWithDice.tsx
+++ b/src/components/CharacterSheet/components/SavingThrowsWithDice.tsx
@@ -77,7 +77,7 @@ export function SavingThrowsWithDice({ character }: SavingThrowsWithDiceProps) {
               </span>
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 className={cn(
                   "h-6 w-6 p-0",
                   "opacity-0 group-hover:opacity-100 transition-opacity",

--- a/src/components/CharacterSheet/components/SkillsWithDice.tsx
+++ b/src/components/CharacterSheet/components/SkillsWithDice.tsx
@@ -132,7 +132,7 @@ export function SkillsWithDice({ character }: SkillsWithDiceProps) {
               </span>
               <Button
                 variant="ghost"
-                size="sm"
+                size="small"
                 className={cn(
                   "h-6 w-6 p-0",
                   "opacity-0 group-hover:opacity-100 transition-opacity",

--- a/src/components/DeleteConfirmationModal.tsx
+++ b/src/components/DeleteConfirmationModal.tsx
@@ -32,10 +32,10 @@ export const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = (
           </Dialog.Description>
 
           <div className="mt-6 flex justify-end gap-3">
-            <Button variant="outline" onClick={onClose}>
+            <Button variant="ghost" onClick={onClose}>
               Cancel
             </Button>
-            <Button variant="destructive" onClick={onConfirm}>
+            <Button variant="danger" onClick={onConfirm}>
               Delete Character
             </Button>
           </div>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -16,7 +16,7 @@ export const EmptyState: React.FC = () => {
       </p>
       
       <Link to="/characters/new">
-        <Button size="lg">
+        <Button size="large">
           <Plus className="w-5 h-5 mr-2" />
           Create Your First Character
         </Button>

--- a/src/components/MobileNavigation.tsx
+++ b/src/components/MobileNavigation.tsx
@@ -29,7 +29,7 @@ function MobileNavigation({ className }: MobileNavigationProps) {
       {/* Mobile menu button */}
       <Button
         variant="ghost"
-        size="icon"
+        size="small"
         onClick={toggleMenu}
         className="touch-target text-white hover:bg-indigo-700"
         aria-label="Toggle navigation menu"
@@ -59,7 +59,7 @@ function MobileNavigation({ className }: MobileNavigationProps) {
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Menu</h2>
             <Button
               variant="ghost"
-              size="icon"
+              size="small"
               onClick={closeMenu}
               className="touch-target"
               aria-label="Close menu"
@@ -99,7 +99,7 @@ function MobileNavigation({ className }: MobileNavigationProps) {
           {/* Bottom actions */}
           <div className="p-4 border-t border-gray-200 dark:border-gray-700">
             <Button
-              variant="outline"
+              variant="ghost"
               onClick={() => {
                 setShowFloatingWidget(!showFloatingWidget)
                 closeMenu()

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -29,7 +29,7 @@ function Navigation() {
       </NavLink>
       <Button
         variant="ghost"
-        size="sm"
+        size="small"
         onClick={() => setShowFloatingWidget(!showFloatingWidget)}
         className="text-indigo-100 hover:bg-indigo-500 hover:text-white"
         title={showFloatingWidget ? "Hide dice roller" : "Show dice roller"}

--- a/src/components/PWA/PWAManager.tsx
+++ b/src/components/PWA/PWAManager.tsx
@@ -109,7 +109,7 @@ export function PWAManager() {
                 Install
               </Button>
               <Button
-                variant="outline"
+                variant="ghost"
                 onClick={() => setShowInstallPrompt(false)}
                 className="flex-1"
               >
@@ -134,15 +134,15 @@ export function PWAManager() {
               <div className="flex gap-2 ml-4">
                 {needRefresh && (
                   <Button
-                    size="sm"
-                    variant="outline"
+                    size="small"
+                    variant="ghost"
                     onClick={() => updateServiceWorker(true)}
                   >
                     Reload
                   </Button>
                 )}
                 <Button
-                  size="sm"
+                  size="small"
                   variant="ghost"
                   onClick={close}
                 >
@@ -162,7 +162,7 @@ export function PWAManager() {
             <AlertDescription className="flex items-center justify-between">
               <span>You're offline. Changes will sync when reconnected.</span>
               <Button
-                size="sm"
+                size="small"
                 variant="ghost"
                 onClick={() => setShowOfflineAlert(false)}
                 className="ml-4"

--- a/src/components/ReferenceSearch/BookmarkManager.tsx
+++ b/src/components/ReferenceSearch/BookmarkManager.tsx
@@ -65,14 +65,14 @@ function BookmarkItem({ bookmark, onRemove, onOpen }: BookmarkItemProps) {
           <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
             <Button
               variant="ghost"
-              size="sm"
+              size="small"
               onClick={() => onOpen(bookmark.category, bookmark.slug)}
             >
               <ExternalLink className="h-4 w-4" />
             </Button>
             <Button
               variant="ghost"
-              size="sm"
+              size="small"
               onClick={() => onRemove(bookmark.id)}
               className="text-red-500 hover:text-red-700"
             >
@@ -156,8 +156,8 @@ export function BookmarkManager() {
 
         <div className="flex gap-2">
           <Button
-            variant={selectedCategory === 'all' ? 'default' : 'outline'}
-            size="sm"
+            variant={selectedCategory === 'all' ? 'primary' : 'ghost'}
+            size="small"
             onClick={() => setSelectedCategory('all')}
           >
             All
@@ -165,8 +165,8 @@ export function BookmarkManager() {
           {Object.entries(categoryLabels).map(([key, label]) => (
             <Button
               key={key}
-              variant={selectedCategory === key ? 'default' : 'outline'}
-              size="sm"
+              variant={selectedCategory === key ? 'primary' : 'ghost'}
+              size="small"
               onClick={() => setSelectedCategory(key as Open5eEndpoint)}
               className="hidden sm:inline-flex"
             >

--- a/src/components/ReferenceSearch/EquipmentBrowser.tsx
+++ b/src/components/ReferenceSearch/EquipmentBrowser.tsx
@@ -52,13 +52,13 @@ function EquipmentCard({ item, onBookmark, isBookmarked }: EquipmentCardProps) {
               <CardTitle className="text-lg">{item.name}</CardTitle>
             </div>
             <div className="flex items-center gap-2 mt-2">
-              <Badge variant="outline">{item.category}</Badge>
+              <Badge variant="secondary">{item.category}</Badge>
               {item.cost && <Badge variant="secondary">{item.cost}</Badge>}
             </div>
           </div>
           <Button
             variant="ghost"
-            size="sm"
+            size="small"
             onClick={() => onBookmark(item)}
           >
             {isBookmarked ? (
@@ -124,7 +124,7 @@ function MagicItemCard({ item, onBookmark, isBookmarked }: MagicItemCardProps) {
               <Badge className={`${rarityColors[item.rarity] || 'bg-gray-500'} text-white`}>
                 {item.rarity}
               </Badge>
-              <Badge variant="outline">{item.type}</Badge>
+              <Badge variant="secondary">{item.type}</Badge>
               {item.requires_attunement === 'requires attunement' && (
                 <Badge variant="secondary">Attunement</Badge>
               )}
@@ -132,7 +132,7 @@ function MagicItemCard({ item, onBookmark, isBookmarked }: MagicItemCardProps) {
           </div>
           <Button
             variant="ghost"
-            size="sm"
+            size="small"
             onClick={() => onBookmark(item)}
           >
             {isBookmarked ? (

--- a/src/components/ReferenceSearch/HelpTooltip.tsx
+++ b/src/components/ReferenceSearch/HelpTooltip.tsx
@@ -28,7 +28,7 @@ export function HelpTooltip({
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
-            size="sm"
+            size="small"
             className={`h-auto p-0.5 hover:bg-transparent ${className}`}
           >
             <HelpCircle className={`text-gray-400 hover:text-gray-600 ${iconClassName}`} />

--- a/src/components/ReferenceSearch/RulesPopup.tsx
+++ b/src/components/ReferenceSearch/RulesPopup.tsx
@@ -73,8 +73,8 @@ export function RulesPopup({ isOpen, onClose, rule }: RulesPopupProps) {
                     return (
                       <Button
                         key={ruleKey}
-                        variant="outline"
-                        size="sm"
+                        variant="ghost"
+                        size="small"
                         onClick={() => {
                           // In a real implementation, this would open the related rule
                           console.log('Open rule:', ruleKey);
@@ -115,12 +115,12 @@ export function RulesPopup({ isOpen, onClose, rule }: RulesPopupProps) {
 // Quick access button for rules
 interface RulesButtonProps {
   ruleKey: string;
-  variant?: 'default' | 'outline' | 'ghost';
-  size?: 'default' | 'sm' | 'lg';
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'success';
+  size?: 'small' | 'medium' | 'large';
   className?: string;
 }
 
-export function RulesButton({ ruleKey, variant = 'ghost', size = 'sm', className }: RulesButtonProps) {
+export function RulesButton({ ruleKey, variant = 'ghost', size = 'small', className }: RulesButtonProps) {
   const rule = rulesDatabase[ruleKey];
   
   if (!rule) return null;

--- a/src/components/ReferenceSearch/SearchModal.tsx
+++ b/src/components/ReferenceSearch/SearchModal.tsx
@@ -176,8 +176,8 @@ export function SearchModal({ isOpen, onClose, onSelect }: SearchModalProps) {
                 {recentSearches.map((search, index) => (
                   <Button
                     key={index}
-                    variant="outline"
-                    size="sm"
+                    variant="ghost"
+                    size="small"
                     onClick={() => setSearchQuery(search)}
                   >
                     {search}
@@ -224,7 +224,7 @@ export function SearchModal({ isOpen, onClose, onSelect }: SearchModalProps) {
                     </div>
                     <Button
                       variant="ghost"
-                      size="sm"
+                      size="small"
                       onClick={(e) => {
                         e.stopPropagation();
                         toggleBookmark(item);

--- a/src/components/ReferenceSearch/SpellBrowser.tsx
+++ b/src/components/ReferenceSearch/SpellBrowser.tsx
@@ -68,14 +68,14 @@ function SpellCard({ spell, onBookmark, isBookmarked }: SpellCardProps) {
               <Badge className={`${schoolColors[spell.school] || 'bg-gray-500'} text-white`}>
                 {spell.school}
               </Badge>
-              <Badge variant="outline">{levelText}</Badge>
+              <Badge variant="secondary">{levelText}</Badge>
               {spell.ritual === 'yes' && <Badge variant="secondary">Ritual</Badge>}
               {spell.concentration === 'yes' && <Badge variant="secondary">Concentration</Badge>}
             </div>
           </div>
           <Button
             variant="ghost"
-            size="sm"
+            size="small"
             onClick={() => onBookmark(spell)}
           >
             {isBookmarked ? (

--- a/src/components/dice/DiceHistory.tsx
+++ b/src/components/dice/DiceHistory.tsx
@@ -38,7 +38,7 @@ export function DiceHistory({ className, maxItems = 50 }: DiceHistoryProps) {
         <CardTitle>Roll History</CardTitle>
         <Button
           variant="ghost"
-          size="sm"
+          size="small"
           onClick={clearHistory}
         >
           Clear History
@@ -63,7 +63,7 @@ export function DiceHistory({ className, maxItems = 50 }: DiceHistoryProps) {
               >
                 <Button
                   variant="ghost"
-                  size="sm"
+                  size="small"
                   className="absolute top-1 right-1 h-6 w-6 p-0"
                   onClick={() => removeFromHistory(roll.id)}
                 >

--- a/src/components/dice/DiceRoller.tsx
+++ b/src/components/dice/DiceRoller.tsx
@@ -137,7 +137,7 @@ export function DiceRoller({ className, onRoll }: DiceRollerProps) {
           onClick={handleRoll}
           disabled={isRolling || !notation.trim()}
           className="w-full"
-          size="lg"
+          size="large"
         >
           {isRolling ? (
             <motion.div
@@ -156,64 +156,64 @@ export function DiceRoller({ className, onRoll }: DiceRollerProps) {
           <Label>Quick Rolls</Label>
           <div className="grid grid-cols-4 gap-2">
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d20', 'D20')}
               disabled={isRolling}
             >
               d20
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d12', 'D12')}
               disabled={isRolling}
             >
               d12
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d10', 'D10')}
               disabled={isRolling}
             >
               d10
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d8', 'D8')}
               disabled={isRolling}
             >
               d8
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d6', 'D6')}
               disabled={isRolling}
             >
               d6
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d4', 'D4')}
               disabled={isRolling}
             >
               d4
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll('1d100', 'D100')}
               disabled={isRolling}
             >
               d100
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll(DICE_SHORTCUTS.abilityScores, 'Stats')}
               disabled={isRolling}
             >
@@ -223,8 +223,8 @@ export function DiceRoller({ className, onRoll }: DiceRollerProps) {
           
           <div className="grid grid-cols-2 gap-2">
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll(DICE_SHORTCUTS.advantage, 'Advantage')}
               disabled={isRolling}
               className="text-green-600"
@@ -232,8 +232,8 @@ export function DiceRoller({ className, onRoll }: DiceRollerProps) {
               Advantage
             </Button>
             <Button
-              variant="outline"
-              size="sm"
+              variant="ghost"
+              size="small"
               onClick={() => handleQuickRoll(DICE_SHORTCUTS.disadvantage, 'Disadvantage')}
               disabled={isRolling}
               className="text-red-600"

--- a/src/components/dice/FloatingDiceWidget.tsx
+++ b/src/components/dice/FloatingDiceWidget.tsx
@@ -30,7 +30,7 @@ export function FloatingDiceWidget() {
                 <div className="flex items-center gap-1">
                   <Button
                     variant="ghost"
-                    size="sm"
+                    size="small"
                     className="h-6 w-6 p-0"
                     onClick={() => setShowHistory(!showHistory)}
                     title={showHistory ? "Show roller" : "Show history"}
@@ -39,7 +39,7 @@ export function FloatingDiceWidget() {
                   </Button>
                   <Button
                     variant="ghost"
-                    size="sm"
+                    size="small"
                     className="h-6 w-6 p-0"
                     onClick={() => setIsOpen(false)}
                     title="Minimize"
@@ -48,7 +48,7 @@ export function FloatingDiceWidget() {
                   </Button>
                   <Button
                     variant="ghost"
-                    size="sm"
+                    size="small"
                     className="h-6 w-6 p-0"
                     onClick={() => setShowFloatingWidget(false)}
                     title="Close widget"

--- a/src/components/import-export/ImportConflictDialog.tsx
+++ b/src/components/import-export/ImportConflictDialog.tsx
@@ -107,7 +107,7 @@ export function ImportConflictDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onCancel}>
+          <Button variant="ghost" onClick={onCancel}>
             Cancel
           </Button>
           <Button onClick={handleResolve}>

--- a/src/components/import-export/ImportExportDialog.tsx
+++ b/src/components/import-export/ImportExportDialog.tsx
@@ -276,7 +276,7 @@ export function ImportExportDialog({
                     <Label>Select Characters</Label>
                     <Button
                       variant="ghost"
-                      size="sm"
+                      size="small"
                       onClick={toggleSelectAll}
                     >
                       {selectedCharacterIds.size === characters.length ? 'Deselect All' : 'Select All'}
@@ -314,7 +314,7 @@ export function ImportExportDialog({
                   <Button
                     onClick={handleExportPDF}
                     disabled={selectedCharacterIds.size !== 1}
-                    variant="outline"
+                    variant="ghost"
                     className="flex-1"
                   >
                     <FileText className="mr-2 h-4 w-4" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,27 +3,91 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/cn';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  'inline-flex items-center justify-center font-medium transition-all duration-300 focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 relative overflow-hidden',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'underline-offset-4 hover:underline text-primary',
+        primary: [
+          'bg-gradient-to-b from-red-800 to-red-900',
+          'text-yellow-200 font-bold',
+          'border-2 border-yellow-600/50',
+          'shadow-lg shadow-red-900/50',
+          'hover:from-red-700 hover:to-red-800',
+          'hover:border-yellow-500',
+          'hover:shadow-xl hover:shadow-red-800/60',
+          'hover:text-yellow-100',
+          'hover:scale-105',
+          'active:scale-95',
+          'active:shadow-inner',
+          'focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+          'after:content-[""] after:absolute after:inset-0 after:bg-gradient-to-t after:from-transparent after:to-white/10 after:opacity-0 hover:after:opacity-100 after:transition-opacity',
+        ].join(' '),
+        
+        secondary: [
+          'bg-gradient-to-b from-purple-800 to-purple-900',
+          'text-purple-200',
+          'border-2 border-purple-400/30',
+          'shadow-lg shadow-purple-900/50',
+          'hover:from-purple-700 hover:to-purple-800',
+          'hover:border-purple-300/50',
+          'hover:shadow-xl hover:shadow-purple-800/60',
+          'hover:text-purple-100',
+          'hover:scale-105',
+          'active:scale-95',
+          'active:shadow-inner',
+          'focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+        ].join(' '),
+        
+        ghost: [
+          'bg-transparent',
+          'text-gray-300',
+          'border border-transparent',
+          'hover:bg-white/5',
+          'hover:border-white/20',
+          'hover:text-white',
+          'hover:shadow-lg hover:shadow-white/10',
+          'active:bg-white/10',
+          'focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+        ].join(' '),
+        
+        danger: [
+          'bg-gradient-to-b from-red-600 to-red-800',
+          'text-red-100',
+          'border-2 border-red-400/50',
+          'shadow-lg shadow-red-900/50',
+          'hover:from-red-500 hover:to-red-700',
+          'hover:border-red-300',
+          'hover:shadow-xl hover:shadow-red-800/60',
+          'hover:animate-pulse',
+          'active:scale-95',
+          'active:shadow-inner',
+          'focus-visible:ring-2 focus-visible:ring-red-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+        ].join(' '),
+        
+        success: [
+          'bg-gradient-to-b from-emerald-700 to-emerald-800',
+          'text-emerald-100',
+          'border-2 border-emerald-400/40',
+          'shadow-lg shadow-emerald-900/50',
+          'hover:from-emerald-600 hover:to-emerald-700',
+          'hover:border-emerald-300/60',
+          'hover:shadow-xl hover:shadow-emerald-800/60',
+          'hover:scale-105',
+          'active:scale-95',
+          'active:shadow-inner',
+          'focus-visible:ring-2 focus-visible:ring-emerald-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900',
+          'before:content-[""] before:absolute before:inset-0 before:bg-[url("data:image/svg+xml,%3Csvg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M20 10 Q25 15 20 20 Q15 15 20 10" fill="none" stroke="%2310b981" stroke-width="0.5" opacity="0.1"/%3E%3C/svg%3E")] before:opacity-30',
+        ].join(' '),
       },
       size: {
-        default: 'h-10 py-2 px-4',
-        sm: 'h-9 px-3 rounded-md',
-        lg: 'h-11 px-8 rounded-md',
-        icon: 'h-10 w-10',
+        small: 'h-9 px-3 text-sm rounded-md gap-1.5',
+        medium: 'h-11 px-5 text-base rounded-lg gap-2',
+        large: 'h-14 px-8 text-lg rounded-xl gap-2.5',
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: 'primary',
+      size: 'medium',
     },
   }
 );
@@ -31,21 +95,95 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+  isLoading?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? 'span' : 'button';
+  ({ 
+    className, 
+    variant, 
+    size, 
+    isLoading, 
+    leftIcon,
+    rightIcon,
+    children,
+    disabled,
+    ...props 
+  }, ref) => {
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+      <button
+        className={cn(
+          buttonVariants({ variant, size, className }),
+          isLoading && 'cursor-wait',
+          disabled && 'cursor-not-allowed relative overflow-hidden',
+          disabled && !isLoading && 'after:content-[""] after:absolute after:inset-0 after:bg-gradient-to-br after:from-transparent after:via-gray-900/80 after:to-transparent after:backdrop-blur-[1px]',
+          disabled && !isLoading && 'before:content-[""] before:absolute before:inset-0 before:bg-[repeating-linear-gradient(45deg,transparent,transparent_10px,rgba(255,255,255,0.1)_10px,rgba(255,255,255,0.1)_11px)]'
+        )}
         ref={ref}
+        disabled={disabled || isLoading}
         {...props}
-      />
+      >
+        {isLoading ? (
+          <>
+            <D20Spinner className="animate-spin" />
+            <span className="ml-2">Loading...</span>
+          </>
+        ) : (
+          <>
+            {leftIcon && <span className="inline-flex shrink-0">{leftIcon}</span>}
+            {children}
+            {rightIcon && <span className="inline-flex shrink-0">{rightIcon}</span>}
+          </>
+        )}
+        
+        {/* Ripple effect container */}
+        <span className="absolute inset-0 pointer-events-none">
+          <span className="ripple" />
+        </span>
+      </button>
     );
   }
 );
 Button.displayName = 'Button';
+
+// D20 Spinner Component
+const D20Spinner: React.FC<{ className?: string }> = ({ className }) => (
+  <svg
+    className={cn("w-5 h-5", className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12 2L2 8V16L12 22L22 16V8L12 2Z"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12 2L12 22"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+    <path
+      d="M2 8L12 14L22 8"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M2 16L12 14L22 16"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
 
 export { Button };

--- a/src/index.css
+++ b/src/index.css
@@ -1168,3 +1168,46 @@
   from { opacity: 1; }
   to { opacity: 0; }
 }
+
+/* Button Ripple Effect */
+@keyframes ripple {
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+.ripple {
+  position: absolute;
+  border-radius: 50%;
+  width: 100px;
+  height: 100px;
+  background: radial-gradient(circle, rgba(255,255,255,0.7) 0%, transparent 70%);
+  transform: scale(0);
+  opacity: 0;
+  pointer-events: none;
+}
+
+button:active .ripple {
+  animation: ripple 0.6s ease-out;
+}
+
+/* Focus Ring Pulse Animation */
+@keyframes focusPulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.8;
+    transform: scale(1.05);
+  }
+}
+
+button:focus-visible {
+  animation: focusPulse 2s ease-in-out infinite;
+}

--- a/src/pages/CharacterList.tsx
+++ b/src/pages/CharacterList.tsx
@@ -121,7 +121,7 @@ const CharacterList: React.FC = () => {
           {/* Mobile Controls */}
           <div className="flex gap-2 md:hidden">
             <Button
-              variant="outline"
+              variant="ghost"
               onClick={() => setShowFilters(!showFilters)}
               className={`flex-1 touch-target ${showFilters ? 'bg-gray-100' : ''}`}
             >
@@ -137,16 +137,16 @@ const CharacterList: React.FC = () => {
             {/* View Mode Toggle Mobile */}
             <div className="flex border rounded-md">
               <Button
-                variant={viewMode === 'grid' ? 'default' : 'ghost'}
-                size="sm"
+                variant={viewMode === 'grid' ? 'primary' : 'ghost'}
+                size="small"
                 onClick={() => setViewMode('grid')}
                 className="rounded-r-none touch-target-sm"
               >
                 <Grid3X3 className="w-4 h-4" />
               </Button>
               <Button
-                variant={viewMode === 'list' ? 'default' : 'ghost'}
-                size="sm"
+                variant={viewMode === 'list' ? 'primary' : 'ghost'}
+                size="small"
                 onClick={() => setViewMode('list')}
                 className="rounded-l-none touch-target-sm"
               >
@@ -159,7 +159,7 @@ const CharacterList: React.FC = () => {
           <div className="hidden md:flex items-center gap-4">
             {/* Filter Toggle */}
             <Button
-              variant="outline"
+              variant="ghost"
               onClick={() => setShowFilters(!showFilters)}
               className={showFilters ? 'bg-gray-100' : ''}
             >
@@ -193,7 +193,7 @@ const CharacterList: React.FC = () => {
 
             {/* Sort Order */}
             <Button
-              variant="outline"
+              variant="ghost"
               onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
               className="px-3"
             >
@@ -203,16 +203,16 @@ const CharacterList: React.FC = () => {
             {/* View Mode Toggle Desktop */}
             <div className="flex border rounded-md">
               <Button
-                variant={viewMode === 'grid' ? 'default' : 'ghost'}
-                size="sm"
+                variant={viewMode === 'grid' ? 'primary' : 'ghost'}
+                size="small"
               onClick={() => setViewMode('grid')}
               className="rounded-r-none"
             >
               <Grid3X3 className="w-4 h-4" />
             </Button>
             <Button
-              variant={viewMode === 'list' ? 'default' : 'ghost'}
-              size="sm"
+              variant={viewMode === 'list' ? 'primary' : 'ghost'}
+              size="small"
               onClick={() => setViewMode('list')}
               className="rounded-l-none"
             >
@@ -312,10 +312,10 @@ const CharacterList: React.FC = () => {
               {selectedIds.length} {selectedIds.length === 1 ? 'character' : 'characters'} selected
             </span>
             <div className="flex gap-2">
-              <Button variant="outline" size="sm" onClick={clearSelection}>
+              <Button variant="ghost" size="small" onClick={clearSelection}>
                 Clear Selection
               </Button>
-              <Button variant="destructive" size="sm" onClick={handleBulkDelete}>
+              <Button variant="danger" size="small" onClick={handleBulkDelete}>
                 Delete Selected
               </Button>
             </div>

--- a/src/pages/Reference.tsx
+++ b/src/pages/Reference.tsx
@@ -46,7 +46,7 @@ export default function Reference() {
         </p>
 
         <div className="flex gap-4 mb-6">
-          <Button onClick={() => setIsSearchOpen(true)} size="lg">
+          <Button onClick={() => setIsSearchOpen(true)} size="large">
             <Search className="mr-2 h-5 w-5" />
             Quick Search
           </Button>
@@ -231,7 +231,7 @@ export default function Reference() {
                     <p className="text-sm text-gray-600">
                       Last cleanup: {new Date(cacheStats.lastCleanup).toLocaleString()}
                     </p>
-                    <Button variant="destructive" onClick={handleClearCache}>
+                    <Button variant="danger" onClick={handleClearCache}>
                       Clear All Cache
                     </Button>
                   </div>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Redesigned button components with a fantasy RPG aesthetic
- Implemented all requested variants, sizes, and interactive states
- Updated all button usages across the codebase

## Implementation Details

### Button Variants
- **Primary**: Deep red gradient with gold text and ornate yellow borders
- **Secondary**: Dark purple gradient with silver accents
- **Ghost**: Transparent with subtle white glow on hover
- **Danger**: Blood red with warning pulse animation on hover
- **Success**: Emerald green with nature-inspired SVG pattern overlay

### Size Variants (Touch-Friendly)
- **Small**: 36px height with appropriate padding
- **Medium**: 44px height (default)
- **Large**: 56px height for important actions

### Interactive States
- **Hover**: Glow effects, color shifts, and slight scale (105%)
- **Active**: Scale down (95%) with inner shadow for pressed feel
- **Focus**: Golden ring with continuous pulsing animation
- **Disabled**: 50% opacity with diagonal stripe pattern overlay
- **Loading**: Spinning D20 icon with "Loading..." text

### Additional Features
- Icon support with `leftIcon` and `rightIcon` props
- Ripple effect on click using CSS animations
- Gradient overlays for depth and shine effects
- Custom D20 spinner SVG for loading state
- Full keyboard navigation support

### Codebase Updates
Updated all button variant and size usages across:
- Character sheets and components
- Navigation components
- Modals and dialogs
- Reference search components
- Dice roller components
- PWA manager
- Import/export dialogs

## Test Plan
- [x] All existing tests pass
- [x] Lint checks pass
- [x] Type checks pass
- [ ] Visual review of all button variants
- [ ] Test hover/active/focus states
- [ ] Test loading and disabled states
- [ ] Verify touch targets on mobile
- [ ] Test keyboard navigation

Closes #31

? Generated with [Claude Code](https://claude.ai/code)
EOF
)